### PR TITLE
Entregas: de tetes unitarios 

### DIFF
--- a/Swift-Git/Swift-Git.xcodeproj/project.pbxproj
+++ b/Swift-Git/Swift-Git.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		29B331334A8804D9D0016A83 /* Pods_Swift_Git.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD0F7B14922E479000B36C06 /* Pods_Swift_Git.framework */; };
 		4795BD28CE96E0F51F0140BE /* Pods_Swift_Git_Swift_GitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CC5C7A3E88BD640073E6F65 /* Pods_Swift_Git_Swift_GitTests.framework */; };
+		F530D2F22480022A00D4FB5B /* RepositoryCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F530D2F12480022A00D4FB5B /* RepositoryCellViewModelTests.swift */; };
 		F5B5CD68247E8A6D009E1061 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B5CD67247E8A6D009E1061 /* AppDelegate.swift */; };
 		F5B5CD6C247E8A6D009E1061 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B5CD6B247E8A6D009E1061 /* ViewController.swift */; };
 		F5B5CD6F247E8A6D009E1061 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F5B5CD6D247E8A6D009E1061 /* Main.storyboard */; };
@@ -37,6 +38,7 @@
 		F5B5CDC8247F0274009E1061 /* UImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B5CDC7247F0274009E1061 /* UImageLoader.swift */; };
 		F5B5CDCB247F02BD009E1061 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B5CDCA247F02BD009E1061 /* ImageLoader.swift */; };
 		F5B5CDCE247F03E2009E1061 /* UImageViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B5CDCD247F03E2009E1061 /* UImageViewExtension.swift */; };
+		F5B5CDD0247F3FEB009E1061 /* RepositoriesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B5CDCF247F3FEB009E1061 /* RepositoriesViewModelTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -56,6 +58,7 @@
 		6BDF4A2CEFA4CCDDEFD546DD /* Pods-Swift-Git.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Swift-Git.debug.xcconfig"; path = "Target Support Files/Pods-Swift-Git/Pods-Swift-Git.debug.xcconfig"; sourceTree = "<group>"; };
 		75E43CFF1B0EFB311A228E26 /* Pods-Swift-Git.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Swift-Git.release.xcconfig"; path = "Target Support Files/Pods-Swift-Git/Pods-Swift-Git.release.xcconfig"; sourceTree = "<group>"; };
 		DD0F7B14922E479000B36C06 /* Pods_Swift_Git.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Swift_Git.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F530D2F12480022A00D4FB5B /* RepositoryCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryCellViewModelTests.swift; sourceTree = "<group>"; };
 		F5B5CD64247E8A6D009E1061 /* Swift-Git.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Swift-Git.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F5B5CD67247E8A6D009E1061 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F5B5CD6B247E8A6D009E1061 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -88,6 +91,7 @@
 		F5B5CDC7247F0274009E1061 /* UImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UImageLoader.swift; sourceTree = "<group>"; };
 		F5B5CDCA247F02BD009E1061 /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
 		F5B5CDCD247F03E2009E1061 /* UImageViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UImageViewExtension.swift; sourceTree = "<group>"; };
+		F5B5CDCF247F3FEB009E1061 /* RepositoriesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoriesViewModelTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -169,6 +173,8 @@
 			children = (
 				F5B5CD7E247E8A6E009E1061 /* Swift_GitTests.swift */,
 				F5B5CD80247E8A6E009E1061 /* Info.plist */,
+				F5B5CDCF247F3FEB009E1061 /* RepositoriesViewModelTests.swift */,
+				F530D2F12480022A00D4FB5B /* RepositoryCellViewModelTests.swift */,
 			);
 			path = "Swift-GitTests";
 			sourceTree = "<group>";
@@ -563,6 +569,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F5B5CDD0247F3FEB009E1061 /* RepositoriesViewModelTests.swift in Sources */,
+				F530D2F22480022A00D4FB5B /* RepositoryCellViewModelTests.swift in Sources */,
 				F5B5CD7F247E8A6E009E1061 /* Swift_GitTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Swift-Git/Swift-Git.xcodeproj/xcshareddata/xcschemes/Swift-Git.xcscheme
+++ b/Swift-Git/Swift-Git.xcodeproj/xcshareddata/xcschemes/Swift-Git.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1150"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F5B5CD63247E8A6D009E1061"
+               BuildableName = "Swift-Git.app"
+               BlueprintName = "Swift-Git"
+               ReferencedContainer = "container:Swift-Git.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F5B5CD79247E8A6E009E1061"
+               BuildableName = "Swift-GitTests.xctest"
+               BlueprintName = "Swift-GitTests"
+               ReferencedContainer = "container:Swift-Git.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F5B5CD63247E8A6D009E1061"
+            BuildableName = "Swift-Git.app"
+            BlueprintName = "Swift-Git"
+            ReferencedContainer = "container:Swift-Git.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F5B5CD63247E8A6D009E1061"
+            BuildableName = "Swift-Git.app"
+            BlueprintName = "Swift-Git"
+            ReferencedContainer = "container:Swift-Git.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Swift-Git/Swift-Git.xcodeproj/xcuserdata/rafaeltorrica.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Swift-Git/Swift-Git.xcodeproj/xcuserdata/rafaeltorrica.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -10,5 +10,18 @@
 			<integer>6</integer>
 		</dict>
 	</dict>
+	<key>SuppressBuildableAutocreation</key>
+	<dict>
+		<key>F5B5CD63247E8A6D009E1061</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>F5B5CD79247E8A6E009E1061</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/Swift-Git/Swift-Git/Features/Search Repository/Model/Item.swift
+++ b/Swift-Git/Swift-Git/Features/Search Repository/Model/Item.swift
@@ -14,3 +14,12 @@ extension Item {
     }
 }
 
+extension Item: Equatable {
+    static func == (lhs: Item, rhs: Item) -> Bool {
+        return lhs.name == rhs.name &&
+        lhs.fullName == rhs.fullName &&
+        lhs.owner == rhs.owner &&
+        lhs.score == rhs.score
+    }
+}
+

--- a/Swift-Git/Swift-Git/Features/Search Repository/Model/Owner.swift
+++ b/Swift-Git/Swift-Git/Features/Search Repository/Model/Owner.swift
@@ -13,3 +13,11 @@ extension Owner {
     }
 }
 
+extension Owner: Equatable {
+    static func == (lhs: Owner, rhs: Owner) -> Bool {
+        return lhs.login == rhs.login &&
+        lhs.avatarUrl == rhs.avatarUrl
+    }
+}
+
+

--- a/Swift-Git/Swift-Git/Features/Search Repository/Model/Repository.swift
+++ b/Swift-Git/Swift-Git/Features/Search Repository/Model/Repository.swift
@@ -10,3 +10,10 @@ extension Repository {
         self.init(totaCount: output.total_count, items: output.items.map { Item(from: $0)} )
     }
 }
+
+extension Repository: Equatable {
+    static func == (lhs: Repository, rhs: Repository) -> Bool {
+        return lhs.totaCount == rhs.totaCount &&
+        lhs.items == rhs.items
+    }
+}

--- a/Swift-Git/Swift-Git/Features/Search Repository/ViewModel/RepositoriesViewModel.swift
+++ b/Swift-Git/Swift-Git/Features/Search Repository/ViewModel/RepositoriesViewModel.swift
@@ -1,4 +1,5 @@
 protocol RepositoriesViewModelProtocol {
+    var repository: Dynamic<Repository?> { get }
     var repositories: Dynamic<[Item]?> { get }
     var error: Dynamic<String?> { get }
     
@@ -7,6 +8,7 @@ protocol RepositoriesViewModelProtocol {
 
 final class RepositoriesViewModel: RepositoriesViewModelProtocol {
     
+    private(set) var repository: Dynamic<Repository?> = Dynamic(nil)
     private(set) var repositories: Dynamic<[Item]?> = Dynamic(nil)
     private(set) var error: Dynamic<String?> = Dynamic(nil)
     private let api: APIRepositoryProviderProtocol
@@ -20,9 +22,10 @@ final class RepositoriesViewModel: RepositoriesViewModelProtocol {
         api.repositories(language: "swift", sort: "stars") { response in
             switch response {
             case.success(let output):
+                self.repository.value = Repository.init(from: output)
                 self.repositories.value = output.items.map { Item(from: $0) }
             case.failure(let error):
-                self.error.value = error.localizedDescription
+                self.error.value = error.description
             }
         }
     }

--- a/Swift-Git/Swift-Git/Network/Clients/APIRepositoryClient.swift
+++ b/Swift-Git/Swift-Git/Network/Clients/APIRepositoryClient.swift
@@ -5,6 +5,6 @@ protocol APIRepositoryProviderProtocol: AnyObject {
 extension API: APIRepositoryProviderProtocol {
     
     func repositories(language: String, sort: String, completion: @escaping (ReturnOutput<RepositoryPayload>) -> Void) {
-        API().request(APIRouter.repositories(language: language, sort: sort), completion: completion)
+        API().request(APIRouter.repositories(language: language, sort: sort, page: 1), completion: completion)
     }
 }

--- a/Swift-Git/Swift-Git/Network/Core/APIRouter.swift
+++ b/Swift-Git/Swift-Git/Network/Core/APIRouter.swift
@@ -5,7 +5,7 @@ internal enum APIRouter: URLRequestConvertible {
     
     //The endpoint name we'll call later
     
-    case repositories(language: String, sort: String)
+    case repositories(language: String, sort: String, page: Int)
     
     //MARK: - URLRequestConvertible
     
@@ -61,9 +61,10 @@ internal enum APIRouter: URLRequestConvertible {
     
     private var parameters: Parameters? {
         switch self {
-        case .repositories(let language, let sort):
+        case .repositories(let language, let sort, let page):
             return [Constants.Parameters.q: "language:\(language)",
-                    Constants.Parameters.sort: sort]
+                    Constants.Parameters.sort: sort,
+                    Constants.Parameters.page: page]
 
         }
     }

--- a/Swift-Git/Swift-Git/Network/Core/Constants.swift
+++ b/Swift-Git/Swift-Git/Network/Core/Constants.swift
@@ -6,6 +6,7 @@ struct Constants {
         static let language = "language"
         static let sort = "sort"
         static let q = "q"
+        static let page = "page"
 
     }
     

--- a/Swift-Git/Swift-Git/Resources/Info.plist
+++ b/Swift-Git/Swift-Git/Resources/Info.plist
@@ -28,11 +28,11 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIStatusBarStyle</key>
+	<string>UIStatusBarStyleLightContent</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>

--- a/Swift-Git/Swift-GitTests/RepositoriesViewModelTests.swift
+++ b/Swift-Git/Swift-GitTests/RepositoriesViewModelTests.swift
@@ -1,0 +1,135 @@
+import Quick
+import Nimble
+
+@testable import Swift_Git
+
+class RepositoriesViewModelTests: QuickSpec {
+    
+    enum State {
+        case success
+        case fail
+    }
+    
+    override func spec() {
+        
+        var spyApi: APIRepositoryProviderSpy!
+        var sut_viewModel: RepositoriesViewModel!
+        
+        describe("MoviesUpcomingPresenter") {
+            
+            func setup(state: State = .fail, error: ApiError = .unknownError("teste")) {
+                spyApi = APIRepositoryProviderSpy(state: state, error: error)
+                sut_viewModel = RepositoriesViewModel(api: spyApi)
+            }
+            
+            beforeEach {
+                setup()
+            }
+            
+            describe("when call fetch repositories called") {
+                
+                context("and the request was completed with repository") {
+                   
+                    it("then should bind repositories to presentation") {
+                        sut_viewModel.loadRepositories()
+                        setup(state: .success)
+                        
+                        let mock = Repository(totaCount: 1, items: [Item(name: "teste", fullName: "teste name", owner: Owner(login: "login", avatarUrl: URL(string: "avatar.com")!), score: 1.2)])
+                        expect(sut_viewModel.repository.value).to(equal(mock))
+                    }
+                }
+                
+                context("and return error 500") {
+                    
+                    it("then should bind error to presentantion") {
+                        sut_viewModel.loadRepositories()
+                        setup(state: .fail, error: .internalServerError)
+                        
+                        expect(sut_viewModel.error.value) == "Internal server error."
+                    }
+                }
+                
+                context("and return error 409") {
+                    
+                    it("then should bind error to presentantion") {
+                        sut_viewModel.loadRepositories()
+                        setup(state: .fail, error: .conflict)
+                        
+                        expect(sut_viewModel.error.value) == "Conflict error."
+                    }
+                }
+                
+                context("and return error 404") {
+                    
+                    it("then should bind error to presentantion") {
+                        sut_viewModel.loadRepositories()
+                        setup(state: .fail, error: .notFound)
+                        
+                        expect(sut_viewModel.error.value) == "The not found failed."
+                    }
+                }
+                
+                context("and return error 403") {
+                    
+                    it("then should bind error to presentantion") {
+                        sut_viewModel.loadRepositories()
+                        setup(state: .fail, error: .forbidden)
+                        
+                        expect(sut_viewModel.error.value) == "Forbidden error."
+                    }
+                }
+                
+                context("and return unknown server error") {
+                    
+                    it("then should bind error to presentantion") {
+                        sut_viewModel.loadRepositories()
+                        setup(state: .fail, error: .unknownError("Unknown server error."))
+                        
+                        expect(sut_viewModel.error.value) == "Unknown server error."
+                    }
+                }
+                
+            }
+        }
+    }
+}
+
+private class APIRepositoryProviderSpy: APIRepositoryProviderProtocol {
+    
+    private let state: RepositoriesViewModelTests.State
+    var repository: RepositoryPayload?
+    var error: ApiError
+    
+    init(state: RepositoriesViewModelTests.State, error: ApiError) {
+        self.state = state
+        self.error = error
+    }
+    
+    func repositories(language: String, sort: String, completion: @escaping (ReturnOutput<RepositoryPayload>) -> Void) {
+        switch state {
+        case .success:
+            completion(.success(.dummy))
+        case .fail:
+            completion(.failure(error))
+        }
+    }
+}
+
+extension RepositoryPayload {
+    static var dummy: RepositoryPayload = {
+        return RepositoryPayload(total_count: 1, incomplete_results: true, items: [ItemPayload.dummyItem])
+    }()
+}
+
+extension ItemPayload {
+    static var dummyItem: ItemPayload = {
+        return ItemPayload(id: 1, node_id: "ad3#$!s", name: "teste", full_name: "teste name", private: false, owner: OwnerPayload.dummyOwner, html_url: "google.com", description: "description teste", fork: false, url: "terra.com", created_at: "2020-05-20T10:35:05Z", updated_at: "2020-05-20T10:35:05Z", pushed_at: "2020-05-20T10:35:05Z", homepage: "homepage.com", size: 123, stargazers_count: 132, watchers_count: 13, language: "swiift", forks_count: 0, open_issues_count: 0, master_branch: "master", default_branch: "master", score: 1.2)
+    }()
+}
+
+extension OwnerPayload {
+    static var dummyOwner: OwnerPayload = {
+        return OwnerPayload(login: "login", id: 1, node_id: "$%!1s", avatar_url: "avatar.com", gravatar_id: "avatar_id", url: "avatar.com", received_events_url: "", type: "user")
+    }()
+}
+

--- a/Swift-Git/Swift-GitTests/RepositoryCellViewModelTests.swift
+++ b/Swift-Git/Swift-GitTests/RepositoryCellViewModelTests.swift
@@ -1,0 +1,46 @@
+import Quick
+import Nimble
+
+@testable import Swift_Git
+
+class RepositoryCellViewModelTests: QuickSpec {
+    
+    override func spec() {
+        
+        var sut_viewModel: RepositoryCellViewModelProtocol!
+        
+        describe("MoviesUpcomingPresenter") {
+            
+            func setup(repository: Item) {
+                sut_viewModel = RepositoryCellViewModel(repository: repository)
+            }
+            
+            describe("when reposytory cell was attached") {
+                
+                beforeEach {
+                    setup(repository: Item.dummy)
+                }
+                
+                it("then should bind properties to presentation") {
+                    expect(sut_viewModel.ownerName.value) == "login"
+                    expect(sut_viewModel.repositoryStars.value) == 1.2
+                    expect(sut_viewModel.repositoryTitle.value) == "teste name"
+                    expect(sut_viewModel.repositoryIcon.value) == #imageLiteral(resourceName: "repositoryIcon")
+                }
+            }
+        }
+    }
+}
+
+extension Item {
+    static var dummy: Item = {
+        return Item(name: "teste", fullName: "teste name", owner: Owner.dummy, score: 1.2)
+    }()
+}
+
+extension Owner {
+    static var dummy: Owner = {
+        return Owner(login: "login", avatarUrl: URL(string: "avatar.com")!)
+    }()
+}
+


### PR DESCRIPTION
	Implementados testes de unidade
		RepositoryCellViewModelTests, cobrindo os binds de propriedades na célula
		RepositoriesViewModelTests, cobrindo os resultados da api, a cobertura os erros e apenas um exemplo, poderíamos ter outros erros mapeados